### PR TITLE
Add albedo and normal map support

### DIFF
--- a/oidnjni/Makefile
+++ b/oidnjni/Makefile
@@ -36,7 +36,7 @@ $(UNPACKED_LIB):	build/$(OIDN_NAME).tar.gz
 	tar -z -x -f $< --touch -C build
 
 build/liboidnjni.so: $(UNPACKED_LIB) $(SRCS)
-	$(CC) -shared -Wl,--no-as-needed $(foreach d, $(INCLUDE), -I$d) $(foreach d, $(LIB), -L$d) -lOpenImageDenoise $(SRCS) -o $@
+	$(CC) -shared -fpic -Wl,--no-as-needed $(foreach d, $(INCLUDE), -I$d) $(foreach d, $(LIB), -L$d) -lOpenImageDenoise $(SRCS) -o $@
 
 .PHONY: clean
 clean:

--- a/oidnjni/Makefile
+++ b/oidnjni/Makefile
@@ -8,7 +8,7 @@ __check_defined = \
 
 $(call check_defined, JAVA_HOME, java home for jni include files)
 
-OIDN_VERSION=1.1.0
+OIDN_VERSION=1.2.2
 
 OIDN_NAME=oidn-$(OIDN_VERSION).x86_64.linux
 OIDN_PATH=$(realpath build/$(OIDN_NAME))

--- a/oidnjni/build.gradle
+++ b/oidnjni/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.internal.jvm.Jvm
 
 ext {
-    oidn_version = "1.1.0"
+    oidn_version = "1.2.2"
     oidn_linux = "oidn-${oidn_version}.x86_64.linux"
     oidn_dir="${buildDir}/${oidn_linux}"
     oidn_libs="${oidn_dir}/lib"

--- a/oidnkt/src/main/kotlin/net/time4tea/oidn/Oidn.kt
+++ b/oidnkt/src/main/kotlin/net/time4tea/oidn/Oidn.kt
@@ -144,8 +144,12 @@ class OidnFilter(private val ptr: Long) : AutoCloseable {
         jniCommit(ptr)
     }
 
+    fun executeTimed() {
+        timed("${javaClass.name}:execute") { execute() }
+    }
+
     fun execute() {
-        timed("${javaClass.name}:execute") { jniExecute(ptr) }
+        jniExecute(ptr)
     }
 
     fun setFilterImage(colour: FloatBuffer, output: FloatBuffer, width: Int, height: Int) {

--- a/oidnkt/src/main/kotlin/net/time4tea/oidn/Oidn.kt
+++ b/oidnkt/src/main/kotlin/net/time4tea/oidn/Oidn.kt
@@ -153,6 +153,13 @@ class OidnFilter(private val ptr: Long) : AutoCloseable {
         jniSetSharedFilterImage(ptr, "output", ensureDirect(output), width, height)
     }
 
+    fun setAdditionalImages(albedo: FloatBuffer, normal: FloatBuffer?, width: Int, height: Int) {
+        jniSetSharedFilterImage(ptr, "albedo", ensureDirect(albedo), width, height)
+        if (normal != null) {
+            jniSetSharedFilterImage(ptr, "normal", ensureDirect(normal), width, height)
+        }
+    }
+
     private fun ensureDirect(buffer: FloatBuffer): FloatBuffer {
         if (!buffer.isDirect) {
             throw IllegalArgumentException("Must be direct")


### PR DESCRIPTION
This PR adds a method to add albedo and normal maps to the filter. It also fixes a linker issue I had on my machine (regarding position-intependent linking, which seems to be required for a shared library).

I also disabled timing output and moved that to a new method (not using a default argument to keep the Java API compatible).